### PR TITLE
Add None flag to RipeSearchRequestFlags and new test case

### DIFF
--- a/TestRipeClientSearch/UnitTest1.cs
+++ b/TestRipeClientSearch/UnitTest1.cs
@@ -28,4 +28,11 @@ public class Tests
         
         Assert.Pass();
     }
+
+    [Test]
+    public async Task Test2()
+    {
+        var reply =
+            await _client.Search(new RipeSearchRequest("45.150.65.0/24", ClientsRipe.TypeFilter.Route));
+    }
 }

--- a/src/ClientsRipe/RipeSearchRequest.cs
+++ b/src/ClientsRipe/RipeSearchRequest.cs
@@ -32,6 +32,10 @@ namespace ClientsRipe
     public enum RipeSearchRequestFlags
     {
         /// <summary>
+        /// None flags
+        /// </summary>
+        None,
+        /// <summary>
         /// -M (or --all-more) - requests that the server should return all the sub-ranges
         /// that are completely contained within the reference range. When there are
         /// hierarchies of sub-ranges, all levels of the hierarchies will be returned down


### PR DESCRIPTION
Introduced the None flag to the RipeSearchRequestFlags enumeration. Also, added a new test case, Test2, to validate search functionality with Route type filter.